### PR TITLE
Some editors don't have `getPath()`

### DIFF
--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -4,7 +4,7 @@ class LinterView
 
   render: ->
     return @hide([]) unless @Linter.ActiveEditor # When we don't have any editor
-    return @hide([]) unless @Linter.ActiveEditor.getPath() # When we have an invalid text editor
+    return @hide([]) unless @Linter.ActiveEditor.getPath?() # When we have an invalid text editor
     @Messages = @renderMessages(@Linter.MessagesProject.values())
     ActiveLinter = @Linter.getActiveEditorLinter()
     if ActiveLinter


### PR DESCRIPTION
I had to make this change in order to be able to focus the Deprication Cop tab.