### PR TITLE
fix naming conventions

### DIFF
--- a/lib/bottom-views.coffee
+++ b/lib/bottom-views.coffee
@@ -1,43 +1,43 @@
 Views = {
-  currentFile:(Linter) ->
-    Root = document.createElement 'div'
-    Root.innerHTML = 'Current File'
-    Root.classList.add 'linter-tab'
-    Root.classList.add 'active'
-    Root.addEventListener 'click', ->
-      Linter.Bottom.BarProject.Root.classList.remove 'active'
-      Root.classList.add 'active'
-      Linter.Panel.Type = 'file'
-      Linter.View.render()
-    Root.appendChild document.createTextNode ' '
-    Child = document.createElement 'span'
-    Child.classList.add 'badge-flexible'
-    Child.textContent = '0'
-    Root.appendChild Child
-    {Root, Child}
-  wholeProject: (Linter) ->
-    Root = document.createElement 'div'
-    Root.innerHTML = 'Project'
-    Root.classList.add 'linter-tab'
-    Root.addEventListener 'click', ->
-      Linter.Bottom.BarCurrent.Root.classList.remove 'active'
-      Root.classList.add 'active'
-      Linter.Panel.Type = 'project'
-      Linter.View.render()
-    Root.appendChild document.createTextNode ' '
-    Child = document.createElement 'span'
-    Child.classList.add 'badge'
-    Child.classList.add 'badge-flexible'
-    Child.textContent = '0'
-    Root.appendChild Child
-    {Root, Child}
+  currentFile:(linter) ->
+    root = document.createElement 'div'
+    root.innerHTML = 'Current File'
+    root.classList.add 'linter-tab'
+    root.classList.add 'active'
+    root.addEventListener 'click', ->
+      linter.bottom.barProject.root.classList.remove 'active'
+      root.classList.add 'active'
+      linter.panel.type = 'file'
+      linter.view.render()
+    root.appendChild document.createTextNode ' '
+    child = document.createElement 'span'
+    child.classList.add 'badge-flexible'
+    child.textContent = '0'
+    root.appendChild child
+    {root, child}
+  wholeProject: (linter) ->
+    root = document.createElement 'div'
+    root.innerHTML = 'Project'
+    root.classList.add 'linter-tab'
+    root.addEventListener 'click', ->
+      linter.bottom.barCurrent.root.classList.remove 'active'
+      root.classList.add 'active'
+      linter.panel.type = 'project'
+      linter.view.render()
+    root.appendChild document.createTextNode ' '
+    child = document.createElement 'span'
+    child.classList.add 'badge'
+    child.classList.add 'badge-flexible'
+    child.textContent = '0'
+    root.appendChild child
+    {root, child}
   status: ->
-    Root = document.createElement 'div'
-    Root.classList.add 'linter-success'
-    Root.classList.add 'inline-block'
-    Child = document.createElement 'span'
-    Child.classList.add 'icon'
-    Root.appendChild Child
-    return {Root, Child}
+    root = document.createElement 'div'
+    root.classList.add 'linter-success'
+    root.classList.add 'inline-block'
+    child = document.createElement 'span'
+    child.classList.add 'icon'
+    root.appendChild child
+    return {root, child}
 }
 module.exports = Views

--- a/lib/bottom.coffee
+++ b/lib/bottom.coffee
@@ -1,44 +1,44 @@
 Views = require './bottom-views'
 
 class Bottom
-  constructor: (@Linter) ->
-    @BarCurrent = null
-    @BarProject = null
-    @BarStatus = null
+  constructor: (@linter) ->
+    @barCurrent = null
+    @barProject = null
+    @barStatus = null
 
-  initialize: (StatusBar) ->
-    @BarCurrent = Views.currentFile(@Linter)
-    @BarProject = Views.wholeProject(@Linter)
-    @BarStatus = Views.status()
-    @BarStatus.Child.classList.add 'icon-check'
-    @BarStatus.Child.textContent = 'No Errors'
-    StatusBar.addLeftTile
-      item: @BarCurrent.Root,
+  initialize: (statusBar) ->
+    @barCurrent = Views.currentFile(@linter)
+    @barProject = Views.wholeProject(@linter)
+    @barStatus = Views.status()
+    @barStatus.child.classList.add 'icon-check'
+    @barStatus.child.textContent = 'No Errors'
+    statusBar.addLeftTile
+      item: @barCurrent.root,
       priority: -1001
-    StatusBar.addLeftTile
-      item: @BarProject.Root,
+    statusBar.addLeftTile
+      item: @barProject.root,
       priority: -1000
-    StatusBar.addLeftTile
-      item: @BarStatus.Root
+    statusBar.addLeftTile
+      item: @barStatus.root
       priority: -999
 
-  update: (Messages) ->
-    CountTotal = Messages.length
-    CountFile = Messages.filter((Message) -> Message.CurrentFile).length
-    @BarCurrent.Child.textContent = CountFile.toString()
-    @BarProject.Child.textContent = CountTotal.toString()
-    if CountTotal
-      @BarStatus.Root.classList.remove 'linter-success'
-      @BarStatus.Root.classList.add 'linter-error'
-      @BarStatus.Child.classList.remove 'icon-check'
-      @BarStatus.Child.classList.add 'icon-x'
-      @BarStatus.Child.textContent = if CountTotal is 1 then '1 Error' else CountTotal + ' Errors'
+  update: (messages) ->
+    countTotal = messages.length
+    countFile = messages.filter((message) -> message.currentFile).length
+    @barCurrent.child.textContent = countFile.toString()
+    @barProject.child.textContent = countTotal.toString()
+    if countTotal
+      @barStatus.root.classList.remove 'linter-success'
+      @barStatus.root.classList.add 'linter-error'
+      @barStatus.child.classList.remove 'icon-check'
+      @barStatus.child.classList.add 'icon-x'
+      @barStatus.child.textContent = if countTotal is 1 then '1 Error' else countTotal + ' Errors'
     else
-      @BarStatus.Root.classList.remove 'linter-error'
-      @BarStatus.Root.classList.add 'linter-success'
-      @BarStatus.Child.classList.remove 'icon-x'
-      @BarStatus.Child.classList.add 'icon-check'
-      @BarStatus.Child.textContent = 'No Errors'
+      @barStatus.root.classList.remove 'linter-error'
+      @barStatus.root.classList.add 'linter-success'
+      @barStatus.child.classList.remove 'icon-x'
+      @barStatus.child.classList.add 'icon-check'
+      @barStatus.child.textContent = 'No Errors'
 
   remove: ->
     # Not removing on purpose

--- a/lib/bubble-view.coffee
+++ b/lib/bubble-view.coffee
@@ -1,8 +1,8 @@
-module.exports = (Linter, Message) ->
-  Root = document.createElement 'div'
-  Root.id = 'linter-inline'
-  Root.appendChild Linter.View.messageLine Message, false
-  if Message.Trace and Message.Trace.length
-    Message.Trace.forEach (Trace) ->
-      Root.appendChild Linter.View.messageLine Trace
-  return Root
+module.exports = (linter, message) ->
+  root = document.createElement 'div'
+  root.id = 'linter-inline'
+  root.appendChild linter.view.messageLine message, false
+  if message.trace and message.trace.length
+    message.trace.forEach (trace) ->
+      root.appendChild linter.view.messageLine trace
+  return root

--- a/lib/bubble.coffee
+++ b/lib/bubble.coffee
@@ -2,26 +2,26 @@
 BubbleView = require './bubble-view'
 
 class Bubble
-  constructor: (@Linter) ->
-    @Bubble = null
+  constructor: (@linter) ->
+    @bubble = null
 
-  update: (Point) ->
+  update: (point) ->
     @remove()
-    return unless @Linter.View.Messages.length
-    TextEditor = @Linter.ActiveEditor
-    Found = false
-    @Linter.View.Messages.forEach (Message) =>
-      return if Found
-      return unless Message.CurrentFile
-      return unless Message.Position
-      P = Message.Position
-      ErrorRange = new Range([P[0][0] - 1, P[0][1] - 1], [P[1][0] - 1, P[1][1]])
-      return unless ErrorRange.containsPoint Point
-      Marker = TextEditor.markBufferRange ErrorRange, {invalidate: 'never'}
-      @Bubble = TextEditor.decorateMarker Marker, type: 'overlay', item: BubbleView(@Linter, Message)
-      Found = true
+    return unless @linter.view.messages.length
+    textEditor = @linter.activeEditor
+    found = false
+    @linter.view.messages.forEach (message) =>
+      return if found
+      return unless message.currentFile
+      return unless message.position
+      p = message.position
+      errorRange = new Range([p[0][0] - 1, p[0][1] - 1], [p[1][0] - 1, p[1][1]])
+      return unless errorRange.containsPoint point
+      marker = textEditor.markBufferRange errorRange, {invalidate: 'never'}
+      @bubble = textEditor.decorateMarker marker, type: 'overlay', item: BubbleView(@linter, message)
+      found = true
 
   remove: ->
-    @Bubble?.destroy()
+    @bubble?.destroy()
 
 module.exports = Bubble

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -1,86 +1,86 @@
 class LinterView
-  constructor: (@Linter) ->
-    @Messages = []
+  constructor: (Linter) ->
+    @messages = []
 
   render: ->
-    return @hide([]) unless @Linter.ActiveEditor # When we don't have any editor
-    return @hide([]) unless @Linter.ActiveEditor.getPath?() # When we have an invalid text editor
+    return @hide([]) unless linter.activeEditor # When we don't have any editor
+    return @hide([]) unless linter.activeEditor.getPath?() # When we have an invalid text editor
 
-    ActiveLinter = @Linter.getActiveEditorLinter()
+    activeLinter = linter.getActiveEditorLinter()
 
-    Messages = @renderMessages(@Linter.MessagesProject.values())
-    Messages = Messages.concat(@renderMessages(ActiveLinter.Messages.values())) if ActiveLinter
-    @Messages = Messages
+    messages = @renderMessages(linter.messagesProject.values())
+    messages = messages.concat(@renderMessages(activeLinter.messages.values())) if activeLinter
+    @messages = messages
 
-    if @Messages.length
-      @Linter.Panel.render @Messages
-      @Linter.PanelModal.show() unless @Linter.PanelModal.isVisible()
+    if @messages.length
+      linter.panel.render @messages
+      linter.panelModal.show() unless linter.panelModal.isVisible()
     else
-      @hide @Messages
+      @hide @messages
 
-    @Linter.Bubble.update @Linter.ActiveEditor.getCursorBufferPosition()
-    @Linter.Bottom.update @Messages
+    linter.bubble.update linter.activeEditor.getCursorBufferPosition()
+    linter.bottom.update @messages
 
-  hide: (Messages) ->
-    @Linter.PanelModal.hide() if @Linter.PanelModal.isVisible()
-    @Linter.Panel.render Messages
+  hide: (messages) ->
+    linter.panelModal.hide() if linter.panelModal.isVisible()
+    linter.panel.render messages
 
-  renderMessages: (Values) ->
-    isProject = @Linter.Panel.Type is 'project'
-    ActiveFile = @Linter.ActiveEditor.getPath()
-    Value = Values.next()
-    ToReturn = []
-    while not Value.done
-      Value.value.forEach (Message) =>
-        if (not Message.File and not isProject) or Message.File is ActiveFile
-          Message.CurrentFile = true
+  renderMessages: (values) ->
+    isProject = linter.panel.type is 'project'
+    activeFile = linter.activeEditor.getPath()
+    value = values.next()
+    toReturn = []
+    while not value.done
+      value.value.forEach (message) =>
+        if (not message.file and not isProject) or message.file is activeFile
+          message.currentFile = true
         else
-          Message.CurrentFile = false
-        ToReturn.push Message
-        @CountProject = @CountProject + 1
-      Value = Values.next()
-    ToReturn
+          message.currentFile = false
+        toReturn.push message
+        @countProject = @countProject + 1
+      value = values.next()
+    toReturn
 
-  messageLine: (Message, addPath = true) ->
-    Entry = document.createElement 'div'
+  messageLine: (message, addPath = true) ->
+    entry = document.createElement 'div'
 
-    Ribbon = document.createElement 'span'
-    Ribbon.classList.add 'badge'
-    Ribbon.classList.add 'badge-flexible'
-    Ribbon.classList.add 'badge-' + Message.Type.toLowerCase()
-    Ribbon.textContent = Message.Type
+    ribbon = document.createElement 'span'
+    ribbon.classList.add 'badge'
+    ribbon.classList.add 'badge-flexible'
+    ribbon.classList.add 'badge-' + message.type.toLowerCase()
+    ribbon.textContent = message.type
 
-    TheMessage = document.createElement('span')
-    if Message.HTML and Message.HTML.length
-      TheMessage.innerHTML = Message.HTML
+    theMessage = document.createElement('span')
+    if message.html and message.html.length
+      theMessage.innerHTML = message.html
     else
-      TheMessage.textContent = Message.Message
+      theMessage.textContent = message.message
 
-    if Message.File
-      Message.DisplayFile = Message.File
+    if message.file
+      message.displayFile = message.file
       try
-        atom.project.getPaths().forEach (Path) ->
-          return unless Message.File.indexOf(Path) is 0
-          Message.DisplayFile = Message.File.substr( Path.length + 1 ) # Remove the trailing slash as well
+        atom.project.getPaths().forEach (path) ->
+          return unless message.file.indexOf(path) is 0
+          message.displayFile = message.file.substr( path.length + 1 ) # Remove the trailing slash as well
           throw null
-      File = document.createElement 'a'
-      File.addEventListener 'click', @onclick.bind(null, Message.File, Message.Position)
-      if Message.Position
-        File.textContent =
-          'at line ' + Message.Position[0][0] + ' col ' + Message.Position[0][1] + ' '
+      file = document.createElement 'a'
+      file.addEventListener 'click', @onclick.bind(null, message.file, message.position)
+      if message.position
+        file.textContent =
+          'at line ' + message.position[0][0] + ' col ' + message.position[0][1] + ' '
       if addPath
-        File.textContent += 'in ' + Message.DisplayFile
+        file.textContent += 'in ' + message.displayFile
     else
-      File = null
+      file = null
 
-    Entry.appendChild Ribbon
-    Entry.appendChild TheMessage
-    Entry.appendChild File if File
-    return Entry
+    entry.appendChild ribbon
+    entry.appendChild theMessage
+    entry.appendChild file if file
+    return entry
 
-  onclick: (File, Position) ->
-    atom.workspace.open(File).then ->
-      return unless Position
-      atom.workspace.getActiveTextEditor().setCursorBufferPosition [Position[0][0] - 1, Position[0][1] - 1]
+  onclick: (file, position) ->
+    atom.workspace.open(file).then ->
+      return unless position
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition [position[0][0] - 1, position[0][1] - 1]
 
 module.exports = LinterView

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -10,61 +10,61 @@ EditorLinter = require './editor-linter'
 class Linter
 
   constructor: ->
-    @Subscriptions = new CompositeDisposable
-    @LintOnFly = true
+    @subscriptions = new CompositeDisposable
+    @lintOnFly = true
 
-    @Emitter = new Emitter
-    @View = new LinterView this
-    @Bottom = new Bottom this
-    @Bubble = new Bubble this
-    @StatusBar = null
-    @MessagesProject = new Map
-    @ActiveEditor = atom.workspace.getActiveTextEditor()
-    @EditorLinters = new Map
-    @Linters = []
+    @emitter = new Emitter
+    @view = new LinterView this
+    @bottom = new Bottom this
+    @bubble = new Bubble this
+    @statusBar = null
+    @messagesProject = new Map
+    @activeEditor = atom.workspace.getActiveTextEditor()
+    @editorLinters = new Map
+    @linters = []
 
-    @Subscriptions.add atom.views.addViewProvider Panel, (Model) =>
-      @PanelView = ( new PanelView() ).initialize(Model, @)
-    @Panel = new Panel this
-    @PanelModal = atom.workspace.addBottomPanel item: @Panel, visible: false
+    @subscriptions.add atom.views.addViewProvider Panel, (model) =>
+      @panelView = ( new PanelView() ).initialize(model, @)
+    @panel = new Panel this
+    @panelModal = atom.workspace.addBottomPanel item: @panel, visible: false
 
-    @Subscriptions.add atom.workspace.onDidChangeActivePaneItem (Editor) =>
-      @ActiveEditor = Editor
-      @View.render()
-    @Subscriptions.add atom.workspace.observeTextEditors (Editor) =>
-      CurrentEditorLinter = new EditorLinter @, Editor
-      @EditorLinters.set Editor, CurrentEditorLinter
-      @Emitter.emit 'linters-observe', CurrentEditorLinter
-      CurrentEditorLinter.lint false
-      Editor.onDidDestroy =>
-        CurrentEditorLinter.destroy()
-        @EditorLinters.delete CurrentEditorLinter
+    @subscriptions.add atom.workspace.onDidChangeActivePaneItem (editor) =>
+      @activeEditor = editor
+      @view.render()
+    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
+      currentEditorLinter = new EditorLinter @, editor
+      @editorLinters.set editor, currentEditorLinter
+      @emitter.emit 'linters-observe', currentEditorLinter
+      currentEditorLinter.lint false
+      editor.onDidDestroy =>
+        currentEditorLinter.destroy()
+        @editorLinters.delete currentEditorLinter
 
   getActiveEditorLinter: ->
-    return null unless @ActiveEditor
-    return @EditorLinters.get @ActiveEditor
+    return null unless @activeEditor
+    return @editorLinters.get @activeEditor
 
-  getLinter: (Editor) ->
-    return @EditorLinters.get Editor
+  getLinter: (editor) ->
+    return @editorLinters.get editor
 
-  eachLinter: (Callback) ->
-    Values = @EditorLinters.values()
-    Value = Values.next()
-    while not Value.done
-      Callback(Value.value)
-      Value = Values.next()
+  eachLinter: (callback) ->
+    values = @editorLinters.values()
+    value = values.next()
+    while not value.done
+      callback(value.value)
+      value = values.next()
 
-  observeLinters: (Callback) ->
-    @eachLinter Callback
-    @Emitter.on 'linters-observe', Callback
+  observeLinters: (callback) ->
+    @eachLinter callback
+    @emitter.on 'linters-observe', callback
 
   deactivate: ->
-    @Subscriptions.dispose()
-    @Panel.removeDecorations()
-    @Bottom.remove()
-    @Bubble.remove()
-    @eachLinter (Linter) ->
-      Linter.Subscriptions.dispose()
-    @PanelModal.destroy()
+    @subscriptions.dispose()
+    @panel.removeDecorations()
+    @bottom.remove()
+    @bubble.remove()
+    @eachLinter (linter) ->
+      linter.subscriptions.dispose()
+    @panelModal.destroy()
 
 module.exports = Linter

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,5 @@
 module.exports =
-  Instance: null
+  instance: null
   config:
     lintOnFly:
       title: 'Lint on fly'
@@ -8,18 +8,18 @@ module.exports =
       default: true
 
   activate: ->
-    @Instance = new (require './linter.coffee')
+    @instance = new (require './linter.coffee')
     atom.config.observe 'linter-plus.lintOnFly', (lintOnyFly) =>
-      @Instance.LintOnFly = lintOnyFly
+      @instance.lintOnFly = lintOnyFly
 
-  consumeLinter: (Linter) ->
-    @Instance.Linters.push Linter
+  consumeLinter: (linter) ->
+    @instance.linters.push linter
 
   consumeStatusBar: (statusBar) ->
-    @Instance.Bottom.initialize(statusBar)
+    @instance.bottom.initialize(statusBar)
 
   provideLinter: ->
     @Linter
 
   deactivate: ->
-    @Instance?.deactivate()
+    @instance?.deactivate()

--- a/lib/panel-view.coffee
+++ b/lib/panel-view.coffee
@@ -1,14 +1,14 @@
 class PanelView extends HTMLElement
-  initialize: (@Model, @Linter) ->
-    @Model.View = this
+  initialize: (@model, @linter) ->
+    @model.view = this
 
   createdCallback: ->
     this.id = 'linter-panel'
 
-  render: (Messages) ->
+  render: (messages) ->
     @innerHTML = ''
-    Messages.forEach (Message) =>
-      return if @Model.Type is 'file' and not Message.CurrentFile
-      @appendChild @Linter.View.messageLine Message, @Model.Type is 'project'
+    messages.forEach (message) =>
+      return if @model.type is 'file' and not message.currentFile
+      @appendChild @linter.view.messageLine message, @model.type is 'project'
 
 module.exports = PanelView = document.registerElement('linter-panel-view', {prototype: PanelView.prototype})

--- a/lib/panel.coffee
+++ b/lib/panel.coffee
@@ -1,34 +1,34 @@
 class Panel
-  constructor: (@Linter) ->
-    @Decorations = []
-    @Type = 'file'
-    @View = null
+  constructor: (@linter) ->
+    @decorations = []
+    @type = 'file'
+    @view = null
 
   removeDecorations: ->
-    return unless @Decorations.length
-    @Decorations.forEach (decoration) ->
+    return unless @decorations.length
+    @decorations.forEach (decoration) ->
       try decoration.destroy()
-    @Decorations = []
+    @decorations = []
 
-  render: (Messages) ->
+  render: (messages) ->
     @removeDecorations()
-    if not Messages.length
-      return @View.innerHTML = ''
-    Messages.forEach (Message) =>
-      return unless Message.CurrentFile # A custom property added while creating arrays of them
-      return unless Message.Position
-      return if @Type is 'file' and (not Message.CurrentFile)
-      P = Message.Position
-      Range = [[P[0][0] - 1, P[0][1] - 1], [P[1][0] - 1, P[1][1]]]
-      Marker = @Linter.ActiveEditor.markBufferRange Range, {invalidate: 'never'}
+    if not messages.length
+      return @view.innerHTML = ''
+    messages.forEach (message) =>
+      return unless message.currentFile # A custom property added while creating arrays of them
+      return unless message.position
+      return if @type is 'file' and (not message.currentFile)
+      p = message.position
+      range = [[p[0][0] - 1, p[0][1] - 1], [p[1][0] - 1, p[1][1]]]
+      marker = @linter.activeEditor.markBufferRange range, {invalidate: 'never'}
 
-      @Decorations.push @Linter.ActiveEditor.decorateMarker(
-        Marker, type: 'line-number', class: 'line-number-' + Message.Type.toLowerCase()
+      @decorations.push @linter.activeEditor.decorateMarker(
+        marker, type: 'line-number', class: 'line-number-' + message.type.toLowerCase()
       )
 
-      @Decorations.push @Linter.ActiveEditor.decorateMarker(
-        Marker, type: 'highlight', class: 'highlight-' + Message.Type.toLowerCase()
+      @decorations.push @linter.activeEditor.decorateMarker(
+        marker, type: 'highlight', class: 'highlight-' + message.type.toLowerCase()
       )
-    @View.render Messages
+    @view.render messages
 
 module.exports = Panel


### PR DESCRIPTION
Use `camelCase` (with a leading lowercase character) to name all variables, methods, and object properties.

Use `CamelCase` (with a leading uppercase character) to name all classes. (This style is also commonly referred to as `PascalCase`, `CamelCaps`, or `CapWords`, among [other alternatives](http://en.wikipedia.org/wiki/CamelCase#Variations_and_synonyms).)

(The **official** CoffeeScript convention is camelcase, because this simplifies interoperability with JavaScript. For more on this decision, see [here](https://github.com/jashkenas/coffee-script/issues/425).)