### PR TITLE
fix naming convention

### DIFF
--- a/lib/bubble-view.coffee
+++ b/lib/bubble-view.coffee
@@ -2,7 +2,7 @@ module.exports = (linter, message) ->
   root = document.createElement 'div'
   root.id = 'linter-inline'
   root.appendChild linter.view.messageLine message, false
-  if message.Trace and message.Trace.length
-    message.Trace.forEach (trace) ->
+  if message.trace and message.trace.length
+    message.trace.forEach (trace) ->
       root.appendChild linter.view.messageLine trace
   return root

--- a/lib/bubble.coffee
+++ b/lib/bubble.coffee
@@ -13,8 +13,8 @@ class Bubble
     @linter.view.messages.forEach (message) =>
       return if found
       return unless message.currentFile
-      return unless message.Position
-      p = message.Position
+      return unless message.position
+      p = message.position
       errorRange = new Range([p[0][0] - 1, p[0][1] - 1], [p[1][0] - 1, p[1][1]])
       return unless errorRange.containsPoint point
       marker = textEditor.markBufferRange errorRange, {invalidate: 'never'}

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -32,7 +32,7 @@ class LinterView
     toReturn = []
     while not value.done
       value.value.forEach (message) =>
-        if (not message.File and not isProject) or message.File is activeFile
+        if (not message.file and not isProject) or message.file is activeFile
           message.currentFile = true
         else
           message.currentFile = false
@@ -47,27 +47,27 @@ class LinterView
     ribbon = document.createElement 'span'
     ribbon.classList.add 'badge'
     ribbon.classList.add 'badge-flexible'
-    ribbon.classList.add 'badge-' + message.Type.toLowerCase()
-    ribbon.textContent = message.Type
+    ribbon.classList.add 'badge-' + message.type.toLowerCase()
+    ribbon.textContent = message.type
 
     theMessage = document.createElement('span')
-    if message.HTML and message.HTML.length
-      theMessage.innerHTML = message.HTML
+    if message.html and message.html.length
+      theMessage.innerHTML = message.html
     else
-      theMessage.textContent = message.Message
+      theMessage.textContent = message.message
 
-    if message.File
-      message.displayFile = message.File
+    if message.file
+      message.displayFile = message.file
       try
         atom.project.getPaths().forEach (path) ->
-          return unless message.File.indexOf(path) is 0
-          message.displayFile = message.File.substr( path.length + 1 ) # Remove the trailing slash as well
+          return unless message.file.indexOf(path) is 0
+          message.displayFile = message.file.substr( path.length + 1 ) # Remove the trailing slash as well
           throw null
       file = document.createElement 'a'
-      file.addEventListener 'click', @onclick.bind(null, message.File, message.Position)
-      if message.Position
+      file.addEventListener 'click', @onclick.bind(null, message.file, message.position)
+      if message.position
         file.textContent =
-          'at line ' + message.Position[0][0] + ' col ' + message.Position[0][1] + ' '
+          'at line ' + message.position[0][0] + ' col ' + message.position[0][1] + ' '
       if addPath
         file.textContent += 'in ' + message.displayFile
     else

--- a/lib/panel.coffee
+++ b/lib/panel.coffee
@@ -16,18 +16,18 @@ class Panel
       return @view.innerHTML = ''
     messages.forEach (message) =>
       return unless message.currentFile # A custom property added while creating arrays of them
-      return unless message.Position
+      return unless message.position
       return if @type is 'file' and (not message.currentFile)
-      p = message.Position
+      p = message.position
       range = [[p[0][0] - 1, p[0][1] - 1], [p[1][0] - 1, p[1][1]]]
       marker = @linter.activeEditor.markBufferRange range, {invalidate: 'never'}
 
       @decorations.push @linter.activeEditor.decorateMarker(
-        marker, type: 'line-number', class: 'line-number-' + message.Type.toLowerCase()
+        marker, type: 'line-number', class: 'line-number-' + message.type.toLowerCase()
       )
 
       @decorations.push @linter.activeEditor.decorateMarker(
-        marker, type: 'highlight', class: 'highlight-' + message.Type.toLowerCase()
+        marker, type: 'highlight', class: 'highlight-' + message.type.toLowerCase()
       )
     @view.render messages
 


### PR DESCRIPTION
now it's work as expected, but you guys need to update what yours linters return

```coffee
...
return new Promise (resolve, reject)->
   message = {type: 'error', message: 'Something went wrong', position:[[1,0], [1,1]], trace: []}
   resolve([message])
```
and we need update docs