### PR TITLE
Fix the background of the popovers

### DIFF
--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -15,9 +15,8 @@
 }
 
 #linter-inline {
-  background-color: @background-color-highlight;
+  background-color: @app-background-color;
   padding: 5px;
-  opacity: 0.8;
 }
 
 atom-text-editor::shadow .line-number-error {


### PR DESCRIPTION
Fixes #37 

I tried keeping the same color by using `fade()` but it just made it white. Using the `@app-background-color` is still close, but not transparent.

![selection_074](https://cloud.githubusercontent.com/assets/324999/8066729/33469e90-0eb7-11e5-868b-aaaac2517745.png)
