### PR TITLE
Config: Show error inline

### DIFF
--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -23,7 +23,7 @@ class EditorLinter
     @subscriptions.add(@editor.onDidSave @lint.bind(@, false))
     @subscriptions.add(@editor.onDidStopChanging @lint.bind(@, true)) if @linter.lintOnFly
     @subscriptions.add(@editor.onDidChangeCursorPosition ({newBufferPosition}) =>
-      @linter.bubble.update newBufferPosition
+      @linter.bubble?.update newBufferPosition
     )
 
   lint: (onChange) ->

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -16,12 +16,21 @@ class Linter
     @emitter = new Emitter
     @view = new LinterView this
     @bottom = new Bottom this
-    @bubble = new Bubble this
     @statusBar = null
     @messagesProject = new Map
     @activeEditor = atom.workspace.getActiveTextEditor()
     @editorLinters = new Map
     @linters = []
+
+    if atom.config.get "editor.showErrorInline"
+      @bubble = new Bubble this
+
+    atom.config.observe 'linter.showErrorInline', (showErrorInline) =>
+      if showErrorInline
+        @bubble = new Bubble this
+      else
+        @bubble?.remove()
+        @bubble = null
 
     @subscriptions.add atom.views.addViewProvider Panel, (model) =>
       @panelView = ( new PanelView() ).initialize(model, @)
@@ -62,7 +71,7 @@ class Linter
     @subscriptions.dispose()
     @panel.removeDecorations()
     @bottom.remove()
-    @bubble.remove()
+    @bubble?.remove()
     @eachLinter (linter) ->
       linter.subscriptions.dispose()
     @panelModal.destroy()

--- a/lib/linter-view.coffee
+++ b/lib/linter-view.coffee
@@ -18,8 +18,8 @@ class LinterView
     else
       @hide @messages
 
-    @linter.bubble.update @linter.activeEditor.getCursorBufferPosition()
-    @linter.bottom.update @messages
+    @linter.bubble?.update @linter.activeEditor.getCursorBufferPosition()
+    @linter.bottom?.update @messages
 
   hide: (messages) ->
     @linter.panelModal.hide() if @linter.panelModal.isVisible()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,6 +6,9 @@ module.exports =
       description: 'Lint files while typing, without the need to save them'
       type: 'boolean'
       default: true
+    showErrorInline:
+      type: 'boolean'
+      default: true
 
   activate: ->
     @instance = new (require './linter-plus.coffee')


### PR DESCRIPTION
I added a config to disable inline "bubble". It uses the same identifier as the current linter, so users will keep there config.