### PR TITLE
Add a try/catch so that we never block switching tabs

### DIFF
--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -39,8 +39,12 @@ class Linter
 
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem (editor) =>
       @activeEditor = editor
-      @getLinter(editor)?.lint(false)
-      @view.render()
+      # Exceptions thrown here prevent switching tabs
+      try
+        @getLinter(editor)?.lint(false)
+        @view.render()
+      catch error
+        atom.notifications.addError error.message, {detail: error.stack, dismissable: true}
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
       currentEditorLinter = new EditorLinter @, editor
       @editorLinters.set editor, currentEditorLinter


### PR DESCRIPTION
#38 fixed the one way I know to trigger this problem, but I'm adding this so it doesn't creep back in through some other bug.

If you want to verify this change add `delete r.type` after [this line](https://github.com/AtomLinter/linter-plus/blob/dont-block-tab-switching/lib/editor-linter.coffee#L9).

Without this change in place it will prevent you from switching to a tab that has a lint error. Your window title will change but you can't actually look at that code.

With this code in place you'll a big error, but it won't prevent you from switching tabs.

![selection_077](https://cloud.githubusercontent.com/assets/324999/8073965/17368b82-0efa-11e5-9a64-72c4b11db404.png)
