### PR TITLE
Simplify editor-linter

### DIFF
--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -33,8 +33,7 @@ class EditorLinter
   lint: (onChange) ->
     return if @editor isnt @linter.activeEditor
 
-    # When linting is triggered by a save we need to also run back through and
-    # run the linters that trigger on the fly.
+    # When linting is triggered on save, we also trigger the onFly linters
     if not onChange
       @lint true
 


### PR DESCRIPTION
* Moving `catch` up the promise chain removes one logical branch. there doesn't
  appear to be any functional difference between deleting the previous results
  and overwriting them with an empty array. It's what would happen if there were
  no errors.
* replacing the `progress` getter/setter with `_promiseLock` makes it clear
  that this is a private function and simplifies the process of setting and
  releasing the lock