### PR TITLE
More Art

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -42,6 +42,6 @@
   },
   "no_implicit_parens":{
     "name": "no_implicit_parens",
-    "level": "error"
+    "level": "warn"
   }
 }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -39,5 +39,9 @@
   "spacing_after_comma": {
     "name": "spacing_after_comma",
     "level": "error"
+  },
+  "no_implicit_parens":{
+    "name": "no_implicit_parens",
+    "level": "error"
   }
 }

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -63,7 +63,7 @@ class EditorLinter
 
   # This method sets or gets the lock status of given type
   _lock: (wasTriggeredOnChange, value) ->
-    key = wasTriggeredOnChange ? '_inProgressFly' : 'inProgress'
+    key = wasTriggeredOnChange ? '_inProgressFly' : '_inProgress'
     if typeof value is 'undefined'
       @[key]
     else

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -63,7 +63,7 @@ class EditorLinter
 
   # This method sets or gets the lock status of given type
   _lock: (wasTriggeredOnChange, value) ->
-    key = wasTriggeredOnChange ? "_inProgressFly" : 'inProgress'
+    key = wasTriggeredOnChange ? '_inProgressFly' : 'inProgress'
     if typeof value is 'undefined'
       @[key]
     else

--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -2,34 +2,34 @@
 
 class EditorLinter
   constructor: (@linter, @editor) ->
-    @inProgress = false
-    @inProgressFly = false
-    @messages = new Map
+    @messages = new Map # Consumed by LinterViews::render
+    @_inProgress = false
+    @_inProgressFly = false
 
-    @emitter = new Emitter
-    @subscriptions = new CompositeDisposable
+    @_emitter = new Emitter
+    @_subscriptions = new CompositeDisposable
 
-    @subscriptions.add(
+    @_subscriptions.add(
       @editor.onDidSave => @lint(false)
     )
-    @subscriptions.add(
+    @_subscriptions.add(
       @editor.onDidChangeCursorPosition ({newBufferPosition}) =>
         @linter.views.updateBubble(newBufferPosition)
     )
-    @subscriptions.add(
+    @_subscriptions.add(
       @editor.onDidStopChanging => @lint(true) if @linter.lintOnFly
     )
 
   # Called on package deactivate
   destroy: ->
-    @emitter.emit 'did-destroy'
-    @subscriptions.dispose()
+    @_emitter.emit 'did-destroy'
+    @_subscriptions.dispose()
 
   onDidUpdate: (callback) ->
-    @emitter.on 'did-update', callback
+    @_emitter.on 'did-update', callback
 
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @_emitter.on 'did-destroy', callback
 
   lint: (wasTriggeredOnChange) ->
     return unless @editor is @linter.activeEditor
@@ -58,12 +58,12 @@ class EditorLinter
         if linter.scope is 'project' then @linter.messagesProject.set linter, results
         else @messages.set linter, results
 
-        @emitter.emit 'did-update'
+        @_emitter.emit 'did-update'
         @linter.views.render() if @editor is @linter.activeEditor
 
   # This method sets or gets the lock status of given type
   _lock: (wasTriggeredOnChange, value) ->
-    key = wasTriggeredOnChange ? 'inProgressFly' : 'inProgress'
+    key = wasTriggeredOnChange ? "_inProgressFly" : 'inProgress'
     if typeof value is 'undefined'
       @[key]
     else
@@ -79,4 +79,5 @@ class EditorLinter
       result.range = Range.fromObject result.range if result.range?
       EditorLinter._validateResults(result.trace) if result.trace
     results
+
 module.exports = EditorLinter

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -6,23 +6,23 @@ H = require './helpers'
 
 class Linter
   constructor: ->
-    @subscriptions = new CompositeDisposable
     @lintOnFly = true # A default art value, to be immediately replaced by the observe config below
+    @_subscriptions = new CompositeDisposable
 
-    @emitter = new Emitter
-    @views = new LinterViews this
-    @messagesProject = new Map
+    @_emitter = new Emitter
+    @_editorLinters = new Map
+    @views = new LinterViews this # Used by editor-linter to trigger views.render
+    @messagesProject = new Map # Values set in editor-linter and consumed in views.render
     @activeEditor = atom.workspace.getActiveTextEditor()
-    @editorLinters = new Map
     @h = H
-    @linters = []
+    @linters = [] # Values are pushed here from Main::consumeLinter
 
     # Bubble
-    @subscriptions.add atom.config.observe 'linter.showErrorInline', (showBubble) =>
+    @_subscriptions.add atom.config.observe 'linter.showErrorInline', (showBubble) =>
       @views.showBubble = showBubble
-    @subscriptions.add atom.config.observe 'linter-plus.lintOnFly', (value) =>
+    @_subscriptions.add atom.config.observe 'linter-plus.lintOnFly', (value) =>
       @lintOnFly = value
-    @subscriptions.add atom.workspace.onDidChangeActivePaneItem (editor) =>
+    @_subscriptions.add atom.workspace.onDidChangeActivePaneItem (editor) =>
       @activeEditor = editor
       # Exceptions thrown here prevent switching tabs
       try
@@ -30,30 +30,30 @@ class Linter
         @views.render()
       catch error
         atom.notifications.addError error.message, {detail: error.stack, dismissable: true}
-    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
+    @_subscriptions.add atom.workspace.observeTextEditors (editor) =>
       currentEditorLinter = new EditorLinter @, editor
-      @editorLinters.set editor, currentEditorLinter
-      @emitter.emit 'linters-observe', currentEditorLinter
+      @_editorLinters.set editor, currentEditorLinter
+      @_emitter.emit 'linters-observe', currentEditorLinter
       currentEditorLinter.lint false
       editor.onDidDestroy =>
         currentEditorLinter.destroy()
-        @editorLinters.delete currentEditorLinter
+        @_editorLinters.delete currentEditorLinter
 
   getActiveEditorLinter: ->
     return @getLinter(@activeEditor)
 
   getLinter: (editor) ->
-    return @editorLinters.get editor
+    return @_editorLinters.get editor
 
   eachLinter: (callback) ->
-    @h.genValue(@editorLinters, callback)
+    @h.genValue(@_editorLinters, callback)
 
   observeLinters: (callback) ->
     @eachLinter callback
-    @emitter.on 'linters-observe', callback
+    @_emitter.on 'linters-observe', callback
 
   deactivate: ->
-    @subscriptions.dispose()
+    @_subscriptions.dispose()
     @eachLinter (linter) ->
       linter.subscriptions.dispose()
     @views.deactivate()

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -55,7 +55,7 @@ class Linter
   deactivate: ->
     @_subscriptions.dispose()
     @eachLinter (linter) ->
-      linter.subscriptions.dispose()
+      linter.destroy()
     @views.deactivate()
 
 module.exports = Linter

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -7,6 +7,7 @@ H = require './helpers'
 class Linter
   constructor: ->
     @subscriptions = new CompositeDisposable
+    @lintOnFly = true # A default art value, to be immediately replaced by the observe config below
 
     @emitter = new Emitter
     @views = new LinterViews this
@@ -16,6 +17,9 @@ class Linter
     @h = H
     @linters = []
 
+    # Bubble
+    @subscriptions.add atom.config.observe 'linter.showErrorInline', (showBubble) =>
+      @views.showBubble = showBubble
     @subscriptions.add atom.config.observe 'linter-plus.lintOnFly', (value) =>
       @lintOnFly = value
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem (editor) =>

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -40,13 +40,13 @@ class Linter
         @_editorLinters.delete currentEditorLinter
 
   getActiveEditorLinter: ->
-    return @getLinter(@activeEditor)
+    return @getLinter @activeEditor
 
   getLinter: (editor) ->
     return @_editorLinters.get editor
 
   eachLinter: (callback) ->
-    @h.genValue(@_editorLinters, callback)
+    @h.genValue @_editorLinters, callback
 
   observeLinters: (callback) ->
     @eachLinter callback

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -56,6 +56,6 @@ class Linter
     @_subscriptions.dispose()
     @eachLinter (linter) ->
       linter.destroy()
-    @views.deactivate()
+    @views.destroy()
 
 module.exports = Linter

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -17,7 +17,6 @@ class Linter
     @h = H
     @linters = [] # Values are pushed here from Main::consumeLinter
 
-    # Bubble
     @_subscriptions.add atom.config.observe 'linter.showErrorInline', (showBubble) =>
       @views.showBubble = showBubble
     @_subscriptions.add atom.config.observe 'linter-plus.lintOnFly', (value) =>

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -4,9 +4,9 @@ Message = require './views/message'
 
 class LinterViews
   constructor: (@linter) ->
+    @showBubble = true # Altered by the config observer in linter-plus
     @_messages = []
     @_decorations = []
-    @_showBubble = true
 
     @_bottomTabFile = new BottomTab()
     @_bottomTabProject = new BottomTab()
@@ -28,9 +28,6 @@ class LinterViews
     @_bottomTabFile.active = true
     @_panel.id = 'linter-panel'
 
-    # Bubble
-    @linter.subscriptions.add atom.config.observe 'linter.showErrorInline', (showBubble) =>
-      @_showBubble = showBubble
 
   # This message is called in editor-linter.coffee
   render: ->
@@ -50,7 +47,7 @@ class LinterViews
   # consumed in editor-linter, _renderPanel
   updateBubble: (point) ->
     @_removeBubble()
-    return unless @_showBubble
+    return unless @showBubble
     return unless @_messages.length
     point = point || @linter.activeEditor.getCursorBufferPosition()
     for message in @_messages

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -83,7 +83,7 @@ class LinterViews
       priority: -999
 
   # this method is called on package deactivate
-  deactivate: ->
+  destroy: ->
     @_panel.removeDecorations()
     @_panelWorkspace.destroy()
     @_removeBubble()

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 linter-message {
   display: block;
-  padding: 2px 0 0 10px;
+  padding: 3px 0 0 0;
   span {
     padding: 3px 5px;
   }
@@ -11,10 +11,13 @@ linter-message {
   display: block;
   overflow-y: scroll;
   max-height: 150px;
+  padding: 0 10px;
 }
 
 #linter-inline {
-  background-color: @app-background-color;
+  opacity: 0.9;
+  border-radius: 15px;
+  background: @base-background-color;
   padding: 5px;
 }
 
@@ -49,6 +52,13 @@ atom-text-editor::shadow .linter-highlight, .linter-highlight{
     color: white;
     .region {
       border-bottom: 1px dashed @background-color-warning;
+    }
+  }
+  &.trace {
+    background-color: @background-color-info;
+    color: white;
+    .region {
+      border-bottom: 1px dashed @background-color-info;
     }
   }
 


### PR DESCRIPTION
#### Notable Changes

- Call directly `EditorLinter.destroy` instead of `EditorLinter.subscriptions.dispose` (which is BAD!)
- Rename `LinterViews::deactivate` to `LinterViews::destroy`
- Shinier tooltips
- `no_implicit_parens` rule has been added to coffeelint.json with a `warn` level