### PR TITLE
Remove lodash dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     }
   },
   "dependencies": {
-    "lodash": "^2.4.1",
     "xregexp": "^2.0.0"
   }
 }


### PR DESCRIPTION
It had only one usage, to clone an array and that was replaced to use `.slice` a while ago. So this is redundant.