### PR TITLE
Restyle

### DIFF
--- a/lib/views/bottom-tab.js
+++ b/lib/views/bottom-tab.js
@@ -5,8 +5,7 @@ class BottomTab extends HTMLElement{
     this.classList.add('linter-tab')
 
     this.countSpan = document.createElement('span')
-    this.countSpan.classList.add('badge')
-    this.countSpan.classList.add('badge-flexible')
+    this.countSpan.classList.add('count')
     this.countSpan.textContent = '0'
 
     this.appendChild(document.createTextNode(' '))

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -3,9 +3,10 @@
 
 linter-message {
   display: block;
-  padding: 3px 0 0 0;
+  padding: 2px;
+  font-size: @font-size;
   span {
-    padding: 3px 5px;
+    padding: 0 6px;
   }
 }
 
@@ -13,14 +14,36 @@ linter-message {
   display: block;
   overflow-y: scroll;
   max-height: 150px;
-  padding: 0 10px;
+  padding: 4px 8px;
 }
 
 #linter-inline {
-  opacity: 0.9;
-  border-radius: 15px;
-  background: @base-background-color;
-  padding: 5px;
+  @linter-inline-link: fade(@base-background-color, 66%);
+  @linter-inline-fg: @base-background-color;
+  @linter-inline-bg: @text-color;
+  margin-top: 4px;
+  padding: 6px;
+  color: @linter-inline-fg;
+  border-radius: @component-border-radius * 1.5;
+  border-top-left-radius: 0;
+  background: @linter-inline-bg;
+  box-shadow: 0 1px 3px hsla(0, 0, 0%, 0.4);
+
+  // pointer arrow
+  &::before {
+    content: "";
+    position: absolute;
+    top: -4px;
+    left: 0;
+    border: 4px solid;
+    border-color: transparent transparent @linter-inline-bg @linter-inline-bg;
+  }
+  a {
+    color: @linter-inline-link;
+  }
+  .badge {
+    margin-top: -2px;
+  }
 }
 
 linter-bottom-tab {
@@ -65,6 +88,9 @@ atom-text-editor::shadow .linter-highlight .icon-right{
 }
 // Styling Error Types
 atom-text-editor::shadow .linter-highlight, .linter-highlight{
+  &.badge {
+    border-radius: @component-border-radius;
+  }
   &.error {
     &:not(.line-number){
       background-color: @background-color-error;

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -25,18 +25,36 @@ linter-message {
 
 linter-bottom-tab {
   display: inline-block;
-  background: @button-background-color;
-  border-radius: 7px;
-  padding: 0 10px;
+  margin-right: -1px; // hide left border
+  padding: 0 .8em;
+  line-height: 2em;
   color: @text-color;
-  margin-right: 1em;
+  border: 1px solid @button-border-color;
+  background: @button-background-color;
   cursor: pointer;
-  line-height: 2.2em;
+  &:first-of-type {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+  }
+  &:last-of-type {
+    margin-right: .75em;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+
   &.active {
     color: @text-color-selected;
     background: @button-background-color-selected;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+  }
+
+  .count {
+    color: inherit;
+    padding: 0;
+    margin-left: .2em;
+    font-size: inherit;
+    border-radius: 0;
+    min-width: 0;
+    background-color: transparent;
   }
 }
 

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -27,26 +27,26 @@ linter-bottom-tab {
   display: inline-block;
   margin-right: -1px; // hide left border
   padding: 0 .8em;
-  line-height: 2em;
-  color: @text-color;
+  line-height: 2.2em;
+  vertical-align: top;
+  color: @text-color-subtle;
   border: 1px solid @button-border-color;
+  border-top: none;
   background: fade(@button-background-color, 33%);
   cursor: pointer;
   &:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-bottom-left-radius: @component-border-radius;
   }
   &:last-of-type {
     margin-right: .75em;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-bottom-right-radius: @component-border-radius;
   }
 
   &:active {
     background: transparent;
   }
   &.active {
-    color: @text-color-selected;
+    color: @text-color-highlight;
     background: @button-background-color;
   }
 

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -30,7 +30,7 @@ linter-bottom-tab {
   line-height: 2em;
   color: @text-color;
   border: 1px solid @button-border-color;
-  background: @button-background-color;
+  background: fade(@button-background-color, 33%);
   cursor: pointer;
   &:first-of-type {
     border-top-left-radius: 4px;
@@ -42,9 +42,12 @@ linter-bottom-tab {
     border-bottom-right-radius: 4px;
   }
 
+  &:active {
+    background: transparent;
+  }
   &.active {
     color: @text-color-selected;
-    background: @button-background-color-selected;
+    background: @button-background-color;
   }
 
   .count {

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -26,19 +26,20 @@ linter-message {
 linter-bottom-tab {
   display: inline-block;
   margin-right: -1px; // hide left border
-  padding: 0 .8em;
-  line-height: 2.2em;
-  vertical-align: top;
+  padding: 0 .6em;
+  line-height: 1.8em;
+  vertical-align: middle;
   color: @text-color-subtle;
   border: 1px solid @button-border-color;
-  border-top: none;
   background: fade(@button-background-color, 33%);
   cursor: pointer;
   &:first-of-type {
+    border-top-left-radius: @component-border-radius;
     border-bottom-left-radius: @component-border-radius;
   }
   &:last-of-type {
-    margin-right: .75em;
+    margin-right: .6em;
+    border-top-right-radius: @component-border-radius;
     border-bottom-right-radius: @component-border-radius;
   }
 

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -22,7 +22,7 @@ linter-message {
   @linter-inline-fg: @base-background-color;
   @linter-inline-bg: @text-color;
   margin-top: 4px;
-  padding: 6px;
+  padding: 4px;
   color: @linter-inline-fg;
   border-radius: @component-border-radius * 1.5;
   border-top-left-radius: 0;
@@ -40,6 +40,7 @@ linter-message {
   }
   a {
     color: @linter-inline-link;
+    margin-right: 4px;
   }
   .badge {
     margin-top: -2px;

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -48,13 +48,7 @@ linter-bottom-tab {
   }
 
   .count {
-    color: inherit;
-    padding: 0;
     margin-left: .2em;
-    font-size: inherit;
-    border-radius: 0;
-    min-width: 0;
-    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
How do you like this:

![screen shot 2015-06-20 at 2 55 26 pm](https://cloud.githubusercontent.com/assets/378023/8266209/77430e6e-175c-11e5-98c4-dd192c5a9d1f.png)
![screen shot 2015-06-20 at 2 56 30 pm](https://cloud.githubusercontent.com/assets/378023/8266220/f496270c-175c-11e5-839d-46a9be343c0f.png)
![screen shot 2015-06-20 at 2 59 03 pm](https://cloud.githubusercontent.com/assets/378023/8266221/fa155658-175c-11e5-9e7d-36db1ed22844.png)

- Tabs are more compact.
- Removed the `.badge`. Having a circle inside a square tab felt a bit too much.

But yeah, it's not that easy to make it look good in all themes.


#### Alternatives:

More like segmented controls. And keeping the `@button-background-color-selected` would make it match the find + replace. But might be too strong since it's visible all the time.

![screen shot 2015-06-20 at 12 07 41 pm](https://cloud.githubusercontent.com/assets/378023/8266224/23776bee-175d-11e5-8655-5dbe2a310bdf.png)

More simplified with just text. But doesn't really look like a toggle.
 
![screen shot 2015-06-20 at 2 33 35 pm](https://cloud.githubusercontent.com/assets/378023/8266226/40a2a184-175d-11e5-99ba-6fee9372a659.png)
