### PR TITLE
Remove no_implicit_parens

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -39,9 +39,5 @@
   "spacing_after_comma": {
     "name": "spacing_after_comma",
     "level": "error"
-  },
-  "no_implicit_parens":{
-    "name": "no_implicit_parens",
-    "level": "warn"
   }
 }


### PR DESCRIPTION
I know I originally recommended this, but given the number of warnings I don't think it's worth the effort. 