### PR TITLE
fix: dispose correctly

### DIFF
--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -35,7 +35,7 @@ class Linter
       currentEditorLinter.lint false
       editor.onDidDestroy =>
         currentEditorLinter.destroy()
-        @_editorLinters.delete currentEditorLinter
+        @_editorLinters.delete editor
 
   addLinter: (linter) ->
     try


### PR DESCRIPTION
`@_editorLinters` wasn't correctly cleared